### PR TITLE
Prevent the notices (login failed, login successul,etc.) form piling up....

### DIFF
--- a/src/BloomLibrary_AngularApp/app/modules/common/notice.js
+++ b/src/BloomLibrary_AngularApp/app/modules/common/notice.js
@@ -1,12 +1,25 @@
 angular.module('palaso.ui.notice', ['ui.bootstrap'])
-.factory('silNoticeService', ['$log', function($log) {
+.factory('silNoticeService', ['$log', '$timeout', function ($log, $timeout) {
 	var notices = [];
 	return {
 		push: function(type, message) {
 			notices.push({type: type(), message: message});
 		},
+		
+        //When we upgrade to angularjs 1.2, we'll use animate to fade the other guys out
+		replace: function (type, message) {
+		    this.push(type, message);
+		    var callme = this;
+		    $timeout(function () {
+		        callme.clear();
+		        callme.push(type, message);
+		    }, 1000);
+		},
 		remove: function(index) {
 			notices.splice(index, 1);
+		},
+		clear: function() {
+		    notices = [];
 		},
 		get: function() {
 			return notices;

--- a/src/BloomLibrary_AngularApp/app/modules/login/login-controller.js
+++ b/src/BloomLibrary_AngularApp/app/modules/login/login-controller.js
@@ -6,9 +6,9 @@ angular.module('BloomLibraryApp.login')
        	$scope.login = function() {
        		authService.login($scope.username, $scope.password, function(result) {
        			if (result.error) {
-	       			silNoticeService.push(silNoticeService.ERROR, result.error);
+       			    silNoticeService.replace(silNoticeService.ERROR, result.error);
        			} else {
-					silNoticeService.push(silNoticeService.SUCCESS, "Login Successful");
+       			    silNoticeService.replace(silNoticeService.SUCCESS, "Login Successful");
 					
 					// add session token to defaultHeaders
 					authService.setSession(result.sessionToken);
@@ -18,16 +18,16 @@ angular.module('BloomLibraryApp.login')
        			if (error.status === 404) {
        				if (error.data.code != undefined) {
        					if (error.data.code === 101) {
-            	       		silNoticeService.push(silNoticeService.ERROR, 
+       					    silNoticeService.replace(silNoticeService.ERROR,
             	       				"Login Unsuccessful. Check your username and password and try again. Also check the Caps Lock key.");
        					} else {
-            	       		silNoticeService.push(silNoticeService.ERROR, error);
+       					    silNoticeService.replace(silNoticeService.ERROR, error);
        					}
        				} else {
-        	       		silNoticeService.push(silNoticeService.ERROR, error);
+       				    silNoticeService.replace(silNoticeService.ERROR, error);
        				}
        			} else {
-    	       		silNoticeService.push(silNoticeService.ERROR, error);
+       			    silNoticeService.replace(silNoticeService.ERROR, error);
        			}
        			
        		});


### PR DESCRIPTION
... All notices now cleared when we change state. We'll probably abandon this stackable-notice thing soon, and overhaul how we give notices to the user, but for now, this at least gets them out of the way.
