### PR TITLE
Switch to new metadata; implement Open in Bloom button

### DIFF
--- a/src/app/modules/browse/browse.tpl.html
+++ b/src/app/modules/browse/browse.tpl.html
@@ -18,16 +18,16 @@
                 <!--                ng-click="viewBook(book)"    >-->
                 <div class="imageContainer">
                     <a ui-sref="browse.detail({bookId: book.objectId})">
-                        <img ng-src="{{book.volumeInfo.imageLinks.thumbnail}}" />
+                        <img ng-src="{{book.thumbnail}}" />
                     </a>
                 </div>
                 <div class="data">
-                    <h3 class="firstRowAboutBook">{{book.volumeInfo.title}}
-                        <div class="author">{{book.volumeInfo.authors | makeCommaList}}</div>
+                    <h3 class="firstRowAboutBook">{{book.title}}
+                        <!--div class="author">{{book.volumeInfo.authors | makeCommaList}}</div-->
                     </h3>
-                    <div class="secondRowAboutBook">
+                    <!--div class="secondRowAboutBook">
                         <div class="pages">{{book.volumeInfo.pageCount}} pages</div>
-                    </div>
+                    </div-->
                 </div>
                 <div class="unfloat"></div>
             </div>

--- a/src/app/modules/common/services.js
+++ b/src/app/modules/common/services.js
@@ -5,8 +5,8 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 		// These headers are the magic keys for our account at Parse.com
 		// While someone is logged on, another header gets added (see setSession).
 		headers = {
-			'X-Parse-Application-Id': 'R6qNTeumQXjJCMutAJYAwPtip1qBulkFyLefkCE5',
-			'X-Parse-REST-API-Key': 'P6dtPT5Hg8PmBCOxhyN9SPmaJ8W4DcckyW0EZkIx'
+			'X-Parse-Application-Id': 'yrXftBF6mbAuVu3fO6LnhCJiHxZPIdE7gl1DUVGR',
+			'X-Parse-REST-API-Key': 'KZA7c0gAuwTD6kZHyO5iZm0t48RplaU7o3SHLKnj'
 		};
 
 		restangularConfig = function (restangularConfigurer) {
@@ -55,7 +55,6 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 				isLoggedIn = false;
 				factory.setSession('');
 			}
-
 		};
 
 		return factory;
@@ -68,7 +67,7 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 		// Enhance: it is probably possible to implement server-side functions and access them using REST instead of
 		// using the parse.com javascript API. We are limiting use of this API to this one file in order to manage
 		// our dependency on parse.com.
-		Parse.initialize('R6qNTeumQXjJCMutAJYAwPtip1qBulkFyLefkCE5', 'bAgoDIISBcscMJTTAY4mBB2RHLfkowkqMBMhQ1CD');
+		Parse.initialize('yrXftBF6mbAuVu3fO6LnhCJiHxZPIdE7gl1DUVGR', '16SZXB7EhUBOBoNol5f8gGypThAiqagG5zmIXfvn');
 		this.getAllBooks = function () {
 			return restangular.withConfig(authService.config()).all('classes/books').getList({ "limit": 50 }).then(function (resultWithWrapper) {
 				return resultWithWrapper.results;
@@ -89,7 +88,7 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 			var defer = $q.defer();
 			var query = new Parse.Query('books');
 			if (searchString) {
-				query.contains('volumeInfo.title', searchString);
+				query.contains('title', searchString);
 			}
 			query.count({
 				success: function (count) {
@@ -122,7 +121,7 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 			query.skip(first);
 			query.limit(count);
 			if (searchString) {
-				query.contains('volumeInfo.title', searchString);
+				query.contains('title', searchString);
 			}
 			// Review: have not yet verified that sorting works at all. At best it probably works only for top-level complete fields.
 			// It does not work for e.g. volumeInfo.title.

--- a/src/app/modules/detail/detail-controller.js
+++ b/src/app/modules/detail/detail-controller.js
@@ -2,8 +2,12 @@
 	'use strict';
 
 	angular.module('BloomLibraryApp.detail', ['ui.router', "restangular"])
-	.config(function config($urlRouterProvider, $stateProvider) {
-
+	.config(function config($urlRouterProvider, $stateProvider, $compileProvider) {
+		// Tell angular that urls starting with bloom: are OK. (Otherwise it marks them 'unsafe' and Chrome at
+		// least won't follow them.). This is needed for the Open in Bloom button.
+		$compileProvider.urlSanitizationWhitelist(/^\s*(https?|bloom):/);
+		// For angular 1.2 this should be changed to
+		//$compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|bloom):/);
 		$stateProvider.state('browse.detail', {
 			url: "/detail/:bookId",
 			onEnter: function ($dialog, $state) {
@@ -40,9 +44,5 @@
 		$scope.$on('$locationChangeSuccess', function (event) {
 			dialog.close();
 		});
-
-		$scope.dowloand = function () {
-			alert('download');
-		};
 	} ]);
 } ());  // end wrap-everything function

--- a/src/app/modules/detail/detail.tpl.html
+++ b/src/app/modules/detail/detail.tpl.html
@@ -5,22 +5,22 @@
         <div class="close" ng-click="close()">x</div>
     </div>
     <div class="modal-body">
-        <img ng-src="{{book.volumeInfo.imageLinks.thumbnail}}" />
+        <img ng-src="{{book.thumbnail}}" />
         <div class="detailCol2">
-            <div class="title">{{book.volumeInfo.title}}</div>
-            <div class="author">{{book.volumeInfo.authors  }}</div>
+            <div class="title">{{book.title}}</div>
+            <!--div class="author">{{book.volumeInfo.authors  }}</div>
             <div class="summary">{{book.volumeInfo.description}}</div>
             <div class="tags">
                 <label>Tags:</label><div ng-repeat="tag in book.volumeInfo.categories">
                     <label><i class="icon-tag"></i>{{tag}}</label>
                 </div>
-            </div>
+            </div-->
             <div class="unfloat"></div>
             <div class="actions">
-                <a ng-href="{{book.volumeInfo.previewLink}}" pdfoverlay>
+                <a ng-href="{{book.previewLink}}" pdfoverlay>
                      
                     <button type="button" class="btn btn-lg"><i class="icon-eye-open"></i>  Preview</button></a>
-                <button type="button" class="btn btn-lg" ng-click="download()"><i class="icon-download"></i>  Open in Bloom</button>
+                <a ng-href="{{book.bookOrder}}"><button type="button" class="btn btn-lg"><i class="icon-download"></i>  Open in Bloom</button></a>
             </div>
 
             <button id="OK" type="button" class="btn btn-info btn-lg" ng-click="close()">OK</button>


### PR DESCRIPTION
(Note: this requires the version of bloom desktop from the BloomLibraryIntegration branch, checkin 364eec60b1c964f7de334783d22597d38f146aba or a descendant.
For the Open in Bloom button to work, registry entries must be created by running the installer or, on  a dev machine, editing and using the registry changes
in "bloom link.reg" in the root directory. Books to be downloaded in this way must also have been uploaded by that version. Also, for now, books to be
downloaded by a debug build must have been uploaded by one. Currently the books are in different buckets on amazon but share one project on parse.com).
