### PR TITLE
Make Preview button in detail view work again

### DIFF
--- a/src/app/modules/app/app.js
+++ b/src/app/modules/app/app.js
@@ -74,7 +74,10 @@
 			link: function (scope, element, attrs) {
 				$(element).fancybox({
 					'overlayShow': true,
-					'type': 'iframe'
+					'type': 'iframe',
+					iframe: {
+						preload: false
+					}
 				});
 			}
 		};


### PR DESCRIPTION
Don't know exactly why we need this fix...I think it skips the display of the 'loading' animation and thus avoids a bug where some browsers don't get notified of the completed download
