### PR TITLE
Hide navigation controls in browse when no books match

### DIFF
--- a/src/app/modules/browse/browse.tpl.html
+++ b/src/app/modules/browse/browse.tpl.html
@@ -10,34 +10,36 @@
         </form>
         <div ng-hide="bookCount==0">matches: {{bookCount}}</div>
         <div ng-show="bookCount==0">Sorry, there are no books that match your search.</div>
-        <ul listview class="books" hide-if-empty="false" item-count="bookCount" page-items-function="getBookRange(first, itemsPerPage)" page-count-tag="browseView">
-            <!--<li class="col-xs-12 col-sm-4 col-md-2" id="Li2"-->
-            <li class="book"
-                ng-repeat="book in visibleBooks">
-                <!-- Was: ng-repeat="book in filteredBooks = (books | filter:matchingBooks) |  startFrom:(currentPage-1)*numPerPage  | limitTo:numPerPage" -->
-                <!--                ng-click="viewBook(book)"    >-->
-                <div class="imageContainer">
-                    <a ui-sref="browse.detail({bookId: book.objectId})">
-                        <img ng-src="{{book.baseUrl | makeThumbnailUrl}}" />
-                    </a>
-                </div>
-                <div class="data">
-                    <a ui-sref="browse.detail({bookId: book.objectId})">
-                        <h3 class="firstRowAboutBook">{{book.title}}</h3>
-                    </a>
-                    <div class="secondRowAboutBook">
-                        <div class="pages">{{book.pageCount}} pages</div>
+        <div ng-hide="bookCount==0">
+            <ul listview class="books" hide-if-empty="true" item-count="bookCount" page-items-function="getBookRange(first, itemsPerPage)" page-count-tag="browseView">
+                <!--<li class="col-xs-12 col-sm-4 col-md-2" id="Li2"-->
+                <li class="book"
+                    ng-repeat="book in visibleBooks">
+                    <!-- Was: ng-repeat="book in filteredBooks = (books | filter:matchingBooks) |  startFrom:(currentPage-1)*numPerPage  | limitTo:numPerPage" -->
+                    <!--                ng-click="viewBook(book)"    >-->
+                    <div class="imageContainer">
+                        <a ui-sref="browse.detail({bookId: book.objectId})">
+                            <img ng-src="{{book.baseUrl | makeThumbnailUrl}}" />
+                        </a>
                     </div>
-                    <div class="languages" ng-show="book.langPointers.length">
-                        Languages: <span ng-repeat="lang in book.langPointers"><a ng-href="http://www.ethnologue.com/language/{{lang.ethnologueCode}}" target="_blank">{{lang.name}}</a><span ng-hide="$last">, </span></span>
+                    <div class="data">
+                        <a ui-sref="browse.detail({bookId: book.objectId})">
+                            <h3 class="firstRowAboutBook">{{book.title}}</h3>
+                        </a>
+                        <div class="secondRowAboutBook">
+                            <div class="pages">{{book.pageCount}} pages</div>
+                        </div>
+                        <div class="languages" ng-show="book.langPointers.length">
+                            Languages: <span ng-repeat="lang in book.langPointers"><a ng-href="http://www.ethnologue.com/language/{{lang.ethnologueCode}}" target="_blank">{{lang.name}}</a><span ng-hide="$last">, </span></span>
+                        </div>
+                        <div class="tags" ng-show="book.tags.length">
+                            Tags: <span ng-repeat="tag in book.tags"><i class="icon-tag"></i>{{tag}} </span>
+                        </div>
                     </div>
-                    <div class="tags" ng-show="book.tags.length">
-                        Tags: <span ng-repeat="tag in book.tags"><i class="icon-tag"></i>{{tag}} </span>
-                    </div>
-                </div>
-                <div class="unfloat"></div>
-            </li>
-        </ul>
+                    <div class="unfloat"></div>
+                </li>
+            </ul>
+        </div>
         <!-- temporary affordance for trying out the new datagrid. Not the final design -->
         <!--form action="#datagrid"><input type="submit" value="Grid view"></form-->
     </div>


### PR DESCRIPTION
Note: the diff is confusing. What mainly happened is that the listview ul moved inside <div ng-hide="bookCount==0">.
I also changed the ul attribute hide-if-empty to true; this didn't do what I expected but did hide some useless clutter
when there is only one page, so I kept it that way.
