### PR TITLE
Sticky footer with terms of use and privacy

### DIFF
--- a/src/app/app.less
+++ b/src/app/app.less
@@ -30,3 +30,26 @@ div.bookshelves
 div.activeFilter {
   font-weight: bold;
 }
+
+/* this group (down to site-footer) are used to implement the sticky footer, using ideas from http://codepen.io/chriscoyier/pen/uwJjr */
+html, body {
+  height: 100%;
+}
+.page-wrap {
+  min-height: 100%;
+  /* equal to site-footer height */
+  margin-bottom: -42px;
+}
+.page-wrap:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+.site-footer, .page-wrap:after {
+  /* equal to page-wrap margin-bottom */
+  height: 42px;
+}
+
+div.footerLinks {
+  float: right;
+}

--- a/src/app/modules/terms/terms.js
+++ b/src/app/modules/terms/terms.js
@@ -15,6 +15,7 @@
 	// Not sure if we need this...there's currently nothing for the controller to do.
 	angular.module('BloomLibraryApp.terms').controller('TermsCtrl', ['$scope',
 		function ($scope) {
+            window.scrollTo(0,0);
 		} ]);
 
 
@@ -33,7 +34,8 @@
 	// Not sure if we need this...there's currently nothing for the controller to do.
 	angular.module('BloomLibraryApp.privacy').controller('PrivacyCtrl', ['$scope',
 		function ($scope) {
-		} ]);
+            window.scrollTo(0,0);
+        } ]);
 
     // This module similarly manages the infringement page that comes up when the user clicks the SIL Notice Policy link in the header
     // or in the Terms page.
@@ -50,5 +52,6 @@
     // Not sure if we need this...there's currently nothing for the controller to do.
     angular.module('BloomLibraryApp.privacy').controller('InfringementCtrl', ['$scope',
         function ($scope) {
+            window.scrollTo(0,0);
         } ]);
 } ());  // end wrap-everything function

--- a/src/index.html
+++ b/src/index.html
@@ -23,6 +23,7 @@
 
   </head>
   <body ng-app="BloomLibraryApp">
+  <div class="page-wrap">
     <div ng-controller="HeaderCtrl">
         <div class="navbar" bs-navbar>
             <div class="navbar-inner">
@@ -30,10 +31,10 @@
                 <div ng-cloak style="float: right" class="nav">
                     <ng-switch class="animate-switch-container" on="isLoggedIn()">
                         <div ng-switch-when="false">
-                            <a href="#/terms">Terms of Use</a><span class="separator">|</span><a href="#/privacy">Privacy</a><span class="separator">|</span><a href="#/signup">Sign Up</a><span class="separator">|</span><a href="#/login">Log In</a>
+                            <a href="#/signup">Sign Up</a><span class="separator">|</span><a href="#/login">Log In</a>
                         </div>
                         <div ng-switch-default>
-                            <a href="#/terms">Terms of Use</a><span class="separator">|</span><a href="#/privacy">Privacy</a><span class="separator">|</span>{{userName()}}
+                            {{userName()}}
                             <a ng-click="logout()">log out</a>
                         </div>
                     </ng-switch>
@@ -41,27 +42,35 @@
             </div>
         </div>
     </div>
-    <div ng-show="wantLeftBar" ng-controller="LeftSidebar" class="span3">
-        <div class="bookshelves">
-            <h4>Bookshelves</h4>
-            <div><a class="bookshelfItem" href="" ng-click="filterShelf('')">All Books</a></div>
-            <div><div ng-class="{activeFilter: currentShelf == 'Featured'}"><a class="bookshelfItem" href="" ng-click="filterShelf('Featured')">Featured</a></div></div>
-            <div><a class="bookshelfItem" href="" ng-click="showInProgress()">New Arrivals</a></div>
-            <div><a class="bookshelfItem" href="" ng-click="showInProgress()">My Uploads</a></div>
+        <div ng-show="wantLeftBar" ng-controller="LeftSidebar" class="span3">
+            <div class="bookshelves">
+                <h4>Bookshelves</h4>
+                <div><a class="bookshelfItem" href="" ng-click="filterShelf('')">All Books</a></div>
+                <div><div ng-class="{activeFilter: currentShelf == 'Featured'}"><a class="bookshelfItem" href="" ng-click="filterShelf('Featured')">Featured</a></div></div>
+                <div><a class="bookshelfItem" href="" ng-click="showInProgress()">New Arrivals</a></div>
+                <div><a class="bookshelfItem" href="" ng-click="showInProgress()">My Uploads</a></div>
+            </div>
+            <div class="narrowSearch">
+                <h4>Narrow Search By</h4>
+                <h5>Languages</h5>
+                <div><a href="" ng-click="filterLanguage('')">Clear</a></div>
+                <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a href="" ng-click="filterLanguage(lang.isoCode)">{{lang.name}}</a></div></div>
+                <h5>Tags</h5>
+                <div><a href="" ng-click="filterTag('')">Clear</a></div>
+                <div ng-repeat="tag in topTags"><div ng-class="{activeFilter: currentTag == tag}"><a class="tagItem" href="" ng-click="filterTag(tag)">{{tag}}</a></div></div>
+            </div>
         </div>
-        <div class="narrowSearch">
-            <h4>Narrow Search By</h4>
-            <h5>Languages</h5>
-            <div><a href="" ng-click="filterLanguage('')">Clear</a></div>
-            <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a href="" ng-click="filterLanguage(lang.isoCode)">{{lang.name}}</a></div></div>
-            <h5>Tags</h5>
-            <div><a href="" ng-click="filterTag('')">Clear</a></div>
-            <div ng-repeat="tag in topTags"><div ng-class="{activeFilter: currentTag == tag}"><a class="tagItem" href="" ng-click="filterTag(tag)">{{tag}}</a></div></div>
+        <div class="span10">
+            <sil-notices></sil-notices>
+            <div ui-view></div>
         </div>
     </div>
-    <div class="span10">
-        <sil-notices></sil-notices>
-        <div ui-view></div>
+    <div class="site-footer">
+        <div class="navbar-inner">
+            <div class="footerLinks">
+                <a href="#/terms">Terms of Use</a><span class="separator">|</span><a href="#/privacy">Privacy</a>
+            </div>
+        </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
index.html diff is confusing. What really happened is, whole former body is wrapped in new
div.page-wrap, and div.site-footer is added below that. Terms of use and privacy links moved there
(and no longer need to be duplicated).

Since terms and privacy can now be invoked when the page is scrolled, added some code to
scroll to top when they are activated.
