### PR TITLE
Deal with remaining css files we were importing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,7 +158,16 @@ module.exports = function ( grunt ) {
             expand: true
           }
         ]
-      }
+      },
+        css_less: {
+            files: [
+                /* some css files need to be just copied to corresponding .less files,
+                 * so we can successfully import them in main.less.
+                 * It would be nicer to make this configurable, with the actual list in build.config.js,
+                 * but I haven't figured out how. */
+                {src: ['vendor/fancybox/source/jquery.fancybox.css'], dest: 'vendor/fancybox/source/jquery.fancybox.less'}
+            ]
+        }
     },
 
     /**
@@ -576,7 +585,7 @@ module.exports = function ( grunt ) {
    * The `build` task gets your app ready to run for development and testing.
    */
   grunt.registerTask( 'build', [
-    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
+    'clean', 'html2js', 'jshint', 'coffeelint', 'coffee', 'copy:css_less', 'less:build',
     'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
     'copy:build_appjs', 'copy:build_vendorjs', 'copy:build_vendorcss', 'index:build', 'karmaconfig',
     'karma:continuous' 

--- a/build.config.js
+++ b/build.config.js
@@ -80,12 +80,12 @@ module.exports = {
     ],
     css: [
         /* most/all of our stylesheets are compiled into on file from less files.
-         The list of those is kept in src/main.less */
-        // This one file does not work when included in main.less. I have not been able to figure out why.
-        // What fails (among other things, possibly) is the tooltips in the detail view, e.g., on the
-        // flag and delete icons and the Open in Bloom button. If bootstrap.css is included instead of linked to,
-        // these tooltips display embedded in the detail view and mess up its layout; they don't look like tooltips.
-        'vendor/bootstrap-css/css/bootstrap.min.css'
+         The list of those is kept in src/main.less.
+         The css section here is basically obsolete, and although I (JohnT) fixed some
+         of the bugs, it doesn't fully work...typically you will have to manually copy
+         the css files listed here to appropriate destinations both locally and on aws.
+         Consider instead extending the list css_less in Gruntfile.js of css files
+         automatically copied to .less, and adding to src/main.less. */
     ],
     assets: [
 		'vendor/fancybox/source/fancybox_sprite.png',

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -8,9 +8,14 @@
 /**
  * First, we include the Twitter Bootstrap LESS files. Only the ones used in the
  * project should be imported as the rest are just wasting space. Review: from ng-boilerplate; do we need (all of) this?
- * Review: would it be better to import the vendor-specific css files specified in build.config.js here?
+ * Note that only .less files get included during the build process (and become part of assets/BloomLibrary-N-.css).
+ * If you put css files in this list, the build process leaves them as @imports, and the target files will need
+ * to be put in the right places.
+ * If you don't have a .less version of what you want, consider extending the css_less list in Gruntfile.js,
+ * and importing the .less version.
  */
 
+@import '../../vendor/bootstrap/less/tooltip.less';
 @import '../../vendor/bootstrap/less/mixins.less';
 @import '../../vendor/bootstrap/less/reset.less';
 @import '../../vendor/bootstrap/less/utilities.less';
@@ -25,7 +30,7 @@
 @import '../../vendor/bootstrap/less/dropdowns.less';
 @import '../../vendor/bootstrap/less/close.less';
 @import '../../vendor/bootstrap/less/modals.less';
-@import '../../vendor/fancybox/source/jquery.fancybox.css';
+@import '../../vendor/fancybox/source/jquery.fancybox.less';
         //'vendor/bootstrap-modal/css/*.css',
          //'vendor/bootstrap-css/css/*.css'
 /**


### PR DESCRIPTION
Instead of linking to bootstrap.min.css, import the piece we were missing, tooltip.less.
Instead of @import jquery.fancybox.css, copy it to jquery.fancybox.less, and @import that,
which our build process converts to merging the file into our master css file.
