### PR TITLE
Make navbar collapse on smaller screens

### DIFF
--- a/build.config.js
+++ b/build.config.js
@@ -80,6 +80,7 @@ module.exports = {
       //'vendor/bootstrap-modal/js/*.js',
       'vendor/bootstrap/js/carousel.js',
       'vendor/bootstrap/js/transition.js',
+      'vendor/bootstrap/js/collapse.js',
       'vendor/angular-local-storage/angular-local-storage.min.js',
       'vendor/jquery-xml2json/src/xml2json.js'
     ],

--- a/src/app/app.less
+++ b/src/app/app.less
@@ -39,9 +39,12 @@ html, body {
 
 div.footerLinks {
   float: right;
-}
-div.footerLinks a.active {
-  color: @bloomRed;
+  a {
+    color: @darkText;
+  }
+  a.active {
+    color: @bloomRed;
+  }
 }
 
 div.notices {
@@ -66,27 +69,56 @@ div.container.not-centered {
   margin-right: 0;
 }
 
+@site-header-font-size: 16px;
 .site-header .navbar {
   border: none;
   border-radius: 0;
 }
-.navbar li.enlarge.active a {
-  font-size: 36px;
-  margin-top: -5px;
+@media (min-width: @grid-float-breakpoint) {
+  .navbar li.enlarge.active a {
+    font-size: @site-header-font-size * 1.75;
+    margin-top: -4px;
+  }
 }
-.site-header .navbar ul.nav {
-  margin: 9px 0px 0px 50px;
+@media (min-width: @grid-float-breakpoint) {
+  .site-header .navbar ul.nav {
+    margin-top: (@navbar-padding-vertical * 2) + 23px;
+  }
 }
 .site-header {
   color: @navbar-inverse-color;
-  font-size: 18px;
+  font-size: @site-header-font-size;
+
+  @media (min-width: @grid-float-breakpoint) {
+    .navbar-collapse {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
 }
 .site-header .user {
-  margin: 15px 15px 0px 0px;
-  line-height: 20px;
+  position: absolute; 
+  top: -15px;
+  right: 0;
+  padding-right: 15px;
+  @media (max-width: @grid-float-breakpoint-max) {
+    display: none;
+  }
 }
 .site-header .navbar-brand {
-  margin-top: -15px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.site-header .navbar-brand img {
+  margin: 10px 0px;
+}
+// The following makes a smoother transition when using two collapsible navbars
+@media (max-width: @grid-float-breakpoint-max) {
+  .navbar-nav.navbar-collapse {
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 .site-footer {
   padding: 10px 25px 10px 10px;

--- a/src/app/modules/app/app.js
+++ b/src/app/modules/app/app.js
@@ -43,6 +43,14 @@
                 return viewLocation === $location.path();
             };
 
+            // When the navbar is open on a small device (i.e. shown vertically),
+            // collapse it when user navigates
+            $(document).on('click','.navbar-collapse.in',function(e) {
+                if( $(e.target).is('a') && !$(e.target).hasClass('dropdown-toggle') ) {
+                    $(this).collapse('hide');
+                }
+            });
+
 	$scope.userName = authService.userName;
 } ])
         .controller('FooterCtrl', ['$scope', '$location', function($scope, $location) {

--- a/src/app/modules/browse/browse.less
+++ b/src/app/modules/browse/browse.less
@@ -176,12 +176,13 @@ li .bookInfo{
 }
 
 .filterBar {
+  //z-index: -1; //So menu goes on top
   background-color: @darkGray;
   color: @lightGray;
   padding-top: 20px;
   position: absolute;
   bottom: 0;
-  top: 94px;
+  top: @navbar-height;
   width: 235px;
   line-height: 20px;
   

--- a/src/index.html
+++ b/src/index.html
@@ -25,42 +25,46 @@
   <body>
     <div class="page-wrap">
         <div class="site-header" ng-controller="HeaderCtrl">
-            <nav class="navbar navbar-inverse" bs-navbar>
-                <div style="padding-right:20px;padding-left:20px">
-                    <a class="navbar-brand" href="#/home"><img src="assets/bloomNavbarLogo.svg"/></a>
-                    <div class="user">
-                        &nbsp;
-                        <span class="pull-right" ng-if="isLoggedIn()">{{userName()}}</span>
+            <nav class="navbar navbar-inverse" role="navigation">
+                <div class="container-fluid">
+                    <div class="navbar-header">
+                        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#site-header-navbar">
+                            <span class="sr-only">Toggle navigation</span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <a class="navbar-brand" href="#/home">
+                            <img src="assets/bloomNavbarLogo.svg"/>
+                        </a>
+                        <div class="user">
+                            &nbsp;
+                            <span class="pull-right" ng-if="isLoggedIn()">{{userName()}}</span>
+                        </div>
                     </div>
-                    <ul class="nav navbar-nav">
-                        <li ng-class="{active: isActive('/home')}" class="home"><a href="#/home">Home</a></li>
-                        <li ng-class="{active: isActive('/features')}"><a href="#/features">Features</a></li>
-                        <li ng-class="{active: isActive('/download')}"><a href="#/installers">Download</a></li>
-                        <li ng-class="{active: isActive('/support')}"><a href="#/support">Support</a></li>
-                        <li ng-class="{active: isActive('/about')||isActive('/opensource')||isActive('/suggestions')}" class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">More <b class="caret"></b></a>
-                            <ul class="dropdown-menu">
-                                <li><a href="#/about">About</a></li>
-                                <li><a href="#/opensource">Open Source</a></li>
-                                <li><a href="#/suggestions">Suggestions</a></li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <ul ng-cloak class="nav navbar-nav navbar-right">
-                        <li ng-class="{active: isActive('/browse')}" class="enlarge"><a href="#/browse">Book Library</a></li>
-                        <ng-switch class="animate-switch-container nav navbar-nav" on="isLoggedIn()">
-                            <span ng-switch-when="false" class="animate-switch nav navbar-nav">
-                                <li ng-class="{active: isActive('/signup')}"><a href="#/signup">Sign Up</a></li>
-                                <li ng-class="{active: isActive('/login')}"><a href="#/login">Log In</a></li>
-                            </span>
-                            <span ng-switch-default class="animate-switch nav navbar-nav">
-                            <li>
-                                <a class="logout" ng-click="logout()">Log Out</a>
+                    <div class="collapse navbar-collapse" id="site-header-navbar">
+                        <ul class="nav navbar-nav">
+                            <li ng-class="{active: isActive('/home')}" class="home"><a href="#/home">Home</a></li>
+                            <li ng-class="{active: isActive('/features')}"><a href="#/features">Features</a></li>
+                            <li ng-class="{active: isActive('/download')}"><a href="#/installers">Download</a></li>
+                            <li ng-class="{active: isActive('/support')||isActive('/about')||isActive('/opensource')||isActive('/suggestions')}" class="dropdown">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown">More <span class="caret"></span></a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="#/support">Support</a></li>
+                                    <li><a href="#/about">About</a></li>
+                                    <li><a href="#/opensource">Open Source</a></li>
+                                    <li><a href="#/suggestions">Suggestions</a></li>
+                                </ul>
                             </li>
-                            </span>
-                        </ng-switch>
-                    </ul>
-                </div>
+                        </ul>
+                        <ul ng-cloak class="nav navbar-nav navbar-right">
+                            <li ng-class="{active: isActive('/browse')}" class="enlarge"><a href="#/browse">Book Library</a></li>
+                            <li ng-class="{active: isActive('/signup')}" ng-if="!isLoggedIn()"><a href="#/signup">Sign Up</a></li>
+                            <li ng-class="{active: isActive('/login')}" ng-if="!isLoggedIn()"><a href="#/login">Log In</a></li>
+                            <li><a class="logout" ng-click="logout()" ng-if="isLoggedIn()">Log Out</a></li>
+                        </ul>
+                    </div>
+                </div><!-- /.container-fluid -->
             </nav>
         </div>
         <sil-notices></sil-notices>

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -4,7 +4,6 @@
  * the Grunt configuration that is automatically processed.
  */
 
-
 /**
  * First, we include the Twitter Bootstrap LESS files. Only the ones used in the
  * project should be imported as the rest are just wasting space. Review: from ng-boilerplate; do we need (all of) this?
@@ -15,34 +14,51 @@
  * and importing the .less version.
  */
 
-@import '../../vendor/bootstrap/less/tooltip.less';
+/**
+ * Attempting to import these in the same order in which they are imported in bootstrap.less for consistency.
+ */
+// Core variables and mixins
 @import '../../vendor/bootstrap/less/mixins.less';
-@import '../../vendor/bootstrap/less/utilities.less';
+
+// Reset
+@import '../../vendor/bootstrap/less/normalize.less';
+
+// Core CSS
 @import '../../vendor/bootstrap/less/scaffolding.less';
 @import '../../vendor/bootstrap/less/type.less';
 @import '../../vendor/bootstrap/less/grid.less';
-@import '../../vendor/bootstrap/less/navs.less';
 @import '../../vendor/bootstrap/less/forms.less';
-@import '../../vendor/bootstrap/less/navbar.less';
 @import '../../vendor/bootstrap/less/buttons.less';
-@import '../../vendor/bootstrap/less/button-groups.less';
+
+// Components
+@import '../../vendor/bootstrap/less/component-animations.less';
 @import '../../vendor/bootstrap/less/dropdowns.less';
-@import '../../vendor/bootstrap/less/close.less';
-@import '../../vendor/bootstrap/less/component-animations.less'; // If component-animations is after modals, modal backdrop is opaque.
-@import '../../vendor/bootstrap/less/modals.less';
-@import '../../vendor/bootstrap/less/carousel.less';
+@import '../../vendor/bootstrap/less/button-groups.less';
 @import '../../vendor/bootstrap/less/input-groups.less';
-@import '../../vendor/bootstrap/less/normalize.less';
+@import '../../vendor/bootstrap/less/navs.less';
+@import '../../vendor/bootstrap/less/navbar.less';
+@import '../../vendor/bootstrap/less/close.less';
+@import '../../vendor/bootstrap/less/modals.less';
+
+// Components w/ JavaScript
+@import '../../vendor/bootstrap/less/tooltip.less';
+@import '../../vendor/bootstrap/less/carousel.less';
+
+// Utility classes
+@import '../../vendor/bootstrap/less/utilities.less';
 @import '../../vendor/bootstrap/less/responsive-utilities.less';
+
+// Non-Bootstrap
 @import '../../vendor/fancybox/source/jquery.fancybox.less';
-        //'vendor/bootstrap-modal/css/*.css',
-         //'vendor/bootstrap-css/css/*.css'
+
+//'vendor/bootstrap-modal/css/*.css',
+//'vendor/bootstrap-css/css/*.css'
+			
 /**
  * This is our main variables file. It in turn imports the `variables` file from
  * Twitter Bootstrap. We must include it last so we can overwrite any variable
  * definitions in our imported stylesheets.
  */
-
 @import 'variables.less';
 
 /**

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -24,11 +24,15 @@
 /**
  * Navbar
  */
+@grid-float-breakpoint: 950px; //Where the navbar collapses
+@navbar-height: 84px;
 @navbar-inverse-color: @lightGray;
 @navbar-inverse-bg: @darkGray;
 @navbar-inverse-link-color: @navbar-inverse-color;
 @navbar-inverse-link-hover-color: @bloomRed;
 @navbar-inverse-link-active-bg: @navbar-inverse-bg;
+@navbar-inverse-toggle-border-color: @navbar-inverse-color;
+@navbar-padding-vertical: 10px;
 
 /**
  * Dropdowns


### PR DESCRIPTION
This has some issues.
1. Clicking log out does not close the menu.  This is, presumably because the event linking isn't performed since the Log Out link is not there when the header is first created.
2. In Book Library, the menu is hidden behind the filter bar.  Setting z-index: -1 on .filterBar makes this work but then causes the filter bar links not to work.  I'm assuming when the navbar is collapsed, we want the sidebar collapsed, too, though.
