### PR TITLE
repair Delete etc. after vendor version changes

### DIFF
--- a/src/app/modules/common/services.js
+++ b/src/app/modules/common/services.js
@@ -99,7 +99,8 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 //                        });
                         restangular.withConfig(restangularConfig).all('classes/bookshelf').getList({ 'where':{'owner': {"__type":"Pointer","className":"_User","objectId":result.objectId} }})
                             .then(function (response) {
-                                bookshelves = response.results;
+                                bookshelves = response;
+                                if (!response) {bookshelves = [];}
                             },
                         function(error) {
                             alert(error);

--- a/src/app/modules/detail/deleteDialog-controller.js
+++ b/src/app/modules/detail/deleteDialog-controller.js
@@ -5,7 +5,7 @@
 		.config(function config($urlRouterProvider, $stateProvider, $compileProvider) {
 		});
 
-	angular.module('BloomLibraryApp.deleteDialog').controller('deleteDialog', ['$scope', 'dialog', 'book',
+	angular.module('BloomLibraryApp.deleteDialog').controller('deleteDialog', ['$scope', '$modalInstance', 'book',
 
 		function ($scope, dialog, book) {
 

--- a/src/app/modules/detail/detail-controller.js
+++ b/src/app/modules/detail/detail-controller.js
@@ -92,7 +92,7 @@
 		//get the book for which we're going to show the details
 		bookService.getBookById($stateParams.bookId).then(function (book) {
 			$scope.book = book;
-			$scope.canDeleteBook = authService.isLoggedIn() && (authService.userName() == book.uploader.email || authService.isUserAdministrator());
+			$scope.canDeleteBook = authService.isLoggedIn() && (authService.userName().toLowerCase() == book.uploader.email.toLowerCase() || authService.isUserAdministrator());
 		});
         $scope.canReportViolation = authService.isLoggedIn(); // We demand this to reduce spamming.
         $scope.canSetBookshelf = authService.isLoggedIn() && authService.bookShelves().length > 0;
@@ -140,8 +140,7 @@
 			var deleteModalInstance = $modal.open({
 				templateUrl: 'modules/detail/deleteDialog.tpl.html',
 				controller: 'deleteDialog',
-				windowClass: 'ccmodal',
-				size: 'sm',
+				windowClass: 'ccmodal deleteConfirm',
 				// this defines the value of 'book' as something that is injected into the BloomLibraryApp.deleteDialog's
 				// controller, thus giving it access to the book whose license we want details about.
 				resolve: {book: function() {return $scope.book;}}
@@ -152,7 +151,7 @@
 					bookService.deleteBook($scope.book.objectId).then(function() {
 						var counts = bookCountService.getCount();
 						counts.bookCount--;
-						dialog.close(true); // object was deleted.
+                        $modalInstance.close(true); // object was deleted.
 					},
 					function(error) {
 						alert(error);

--- a/src/app/modules/detail/detail.less
+++ b/src/app/modules/detail/detail.less
@@ -6,6 +6,11 @@
 	margin-top: 17px;
 	margin-left: 15px;
 	margin-right: 17px;
+    overflow: hidden;
+}
+
+.deleteConfirm .modal-dialog {
+  width: 450px;
 }
 .modal IMG
 {


### PR DESCRIPTION
- Make the delete confirmation dialog a little wider to allow for two wide buttons
- Fix a query glitch that prevented the detail view opening while logged on
- Delete permission required another toLowerCase to allow enabling for mixed-case usernames
- Get Delete actually working
