### PR TITLE
Improve logo

### DIFF
--- a/src/assets/bloomNavbarLogo.svg
+++ b/src/assets/bloomNavbarLogo.svg
@@ -9,8 +9,8 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="187"
-   height="65"
+   width="200"
+   height="64.220001"
    id="svg3436"
    version="1.1"
    inkscape:version="0.48.4 r9939"
@@ -24,9 +24,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="105.21724"
-     inkscape:cy="51.213444"
+     inkscape:zoom="2"
+     inkscape:cx="262.32323"
+     inkscape:cy="-19.420142"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -34,18 +34,11 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="1808"
+     inkscape:window-width="1704"
      inkscape:window-height="1177"
      inkscape:window-x="1192"
      inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <sodipodi:guide
-       orientation="1,0"
-       position="185.5,-1.375"
-       id="guide2995" />
-  </sodipodi:namedview>
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata3441">
     <rdf:RDF>
@@ -62,133 +55,128 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-191.13213,-465.09218)">
+     transform="translate(-191.13213,-465.87218)">
+    <text
+       xml:space="preserve"
+       style="font-size:10.47552776px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#e5e5e5;fill-opacity:1;stroke:none;font-family:Sans"
+       x="277.91028"
+       y="495.44574"
+       id="text4939-0-5-9-6-1-6-3-7"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
+       inkscape:export-xdpi="49.189999"
+       inkscape:export-ydpi="49.189999"><tspan
+         sodipodi:role="line"
+         id="tspan4941-7-9-0-5-7-3-0-4"
+         x="277.91028"
+         y="495.44574"
+         style="font-size:9.65415573px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#e5e5e5;fill-opacity:1;stroke:none;font-family:Arial, Sans-Serif, Sans;-inkscape-font-specification:Arial Bold, Sans-Serif Bold, Sans Bold">let's grow a library</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:51.07364655px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#d65649;fill-opacity:1;stroke:none;font-family:Sans"
+       x="244.97806"
+       y="508.33444"
+       id="text4484-8-0-2-7-9-2-4-9-9-2-0-7-0-4-6-3-0"
+       sodipodi:linespacing="125%"
+       transform="scale(0.96627889,1.0348979)"
+       inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
+       inkscape:export-xdpi="49.189999"
+       inkscape:export-ydpi="49.189999"><tspan
+         sodipodi:role="line"
+         id="tspan4486-1-4-7-0-1-9-2-5-8-9-9-0-9-0-8-0-9"
+         x="244.97806"
+         y="508.33444"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:-2.34059405px;fill:#d65649;fill-opacity:1;stroke:none;font-family:Palatino Linotype, Galatia SIL, Times New Roman, Serif;-inkscape-font-specification:Palatino Linotype, Galatia SIL, Times New Roman, Serif">Bloom</tspan></text>
     <g
-       id="g3723"
-       transform="translate(348.67339,-176.86124)">
-      <text
-         transform="scale(0.95472567,1.0474213)"
-         inkscape:export-ydpi="49.189999"
-         inkscape:export-xdpi="49.189999"
-         inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
-         sodipodi:linespacing="125%"
-         id="text4939-0-5-9-6-1-6-3-7-7"
-         y="644.3114"
-         x="-65.254471"
-         style="font-size:11.37053013px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#e5e5e5;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-         xml:space="preserve"><tspan
-           style="font-size:11.37053013px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#e5e5e5;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-           y="644.3114"
-           x="-65.254471"
-           id="tspan4941-7-9-0-5-7-3-0-4-6"
-           sodipodi:role="line">let's grow a library</tspan></text>
-      <text
-         inkscape:export-ydpi="49.189999"
-         inkscape:export-xdpi="49.189999"
-         inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
-         transform="scale(0.96627889,1.0348979)"
-         sodipodi:linespacing="125%"
-         id="text4484-8-0-2-7-9-2-4-9-9-2-0-7-0-4-6-3-0-1"
-         y="681.03369"
-         x="-113.65843"
-         style="font-size:56.26199341px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#d65649;fill-opacity:1;stroke:none;font-family:Serif;-inkscape-font-specification:Serif"
-         xml:space="preserve"><tspan
-           style="font-size:56.26199341px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:-2.57836485px;writing-mode:lr-tb;text-anchor:start;fill:#d65649;fill-opacity:1;stroke:none;font-family:Serif;-inkscape-font-specification:Serif"
-           y="681.03369"
-           x="-113.65843"
-           id="tspan4486-1-4-7-0-1-9-2-5-8-9-9-0-9-0-8-0-9-4"
-           sodipodi:role="line">Bloom</tspan></text>
-      <g
-         inkscape:export-ydpi="49.189999"
-         inkscape:export-xdpi="49.189999"
-         inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
-         transform="matrix(0.48270778,0,0,0.48270778,1169.2064,-802.57452)"
-         id="g12117-48-2">
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           sodipodi:nodetypes="cccccccccsc"
-           inkscape:connector-curvature="0"
-           id="path3103-2-6-5-2-4-1-3-2-0-3-3-4-9-8-8-4-8-3"
-           d="m -2712.6495,3028.3151 c 14.9012,-1.8246 25.5449,-1.5205 25.5449,-1.5205 32.5391,29.8023 31.776,23.8975 34.2089,36.0617 l -2.7034,4.487 c -10.9478,-0.6083 -30.2891,-25.6476 -30.2891,-25.6476 l 1.2164,51.0898 -24.6326,0 -0.6082,-50.1774 c -21.9768,19.4439 -28.9013,26.5594 -34.6679,25.8489 -1.1905,-1.9557 0.3412,-6.5174 1.2436,-8.9735 2.128,-5.7927 30.6874,-31.1684 30.6874,-31.1684 z"
-           style="fill:#e5e5e5;fill-opacity:1;stroke:none" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           inkscape:connector-curvature="0"
-           id="path10-8-1-3-4-7-0-0-5-4-2-2-7-5-5-3-5-8-2-4-2-2"
-           d="m -2740.377,3041.946 0,42.3316 c 0,23.3746 18.957,42.3175 42.3316,42.3175 23.3746,0 42.3173,-18.9429 42.3173,-42.3175 l 0,-42.3316 c -23.3745,0 -53.1594,23.127 -34.6445,51.0052 -3.5028,-23.3746 -26.6298,-51.0052 -50.0044,-51.0052 z"
-           style="fill:#d65649;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
-           sodipodi:nodetypes="csssccc" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           transform="matrix(0.28824494,0,0,0.28824494,-2538.3392,2872.0462)"
-           d="m -503.33473,476.20172 a 54.447071,54.447071 0 1 1 -108.89414,0 54.447071,54.447071 0 1 1 108.89414,0 z"
-           sodipodi:ry="54.447071"
-           sodipodi:rx="54.447071"
-           sodipodi:cy="476.20172"
-           sodipodi:cx="-557.7818"
-           id="path3101-5-6-7-9-0-4-9-4-7-0-8-3-0-2-4-3-4-2"
-           style="fill:#e5e5e5;fill-opacity:1;stroke:none"
-           sodipodi:type="arc" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           sodipodi:nodetypes="cccc"
-           inkscape:connector-curvature="0"
-           id="path4441-5-7-9-8-3-0-0-5-5-2-7-8-2-45-5-3-5-1"
-           d="m -2655.7902,3041.7672 c -30.0055,2.7604 -38.6419,19.9107 -41.3979,31.5296 m 5.2743,34.9198 c 3.209,-39.5982 -17.6691,-62.0499 -48.1148,-66.4494"
-           style="fill:none;stroke:#e5e5e5;stroke-width:3.03664303;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           transform="matrix(0.72426329,0,0,1,-189.65951,543.52926)"
-           d="m -3519,2522.0313 a 4.625,5.625 0 1 1 -9.25,0 4.625,5.625 0 1 1 9.25,0 z"
-           sodipodi:ry="5.625"
-           sodipodi:rx="4.625"
-           sodipodi:cy="2522.0312"
-           sodipodi:cx="-3523.625"
-           id="path5011-0-8-51-6"
-           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:#e5e5e5;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-           sodipodi:type="arc" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           transform="matrix(0.64864865,0,0,1,-370.57191,540.77926)"
-           d="m -3519,2522.0313 a 4.625,5.625 0 1 1 -9.25,0 4.625,5.625 0 1 1 9.25,0 z"
-           sodipodi:ry="5.625"
-           sodipodi:rx="4.625"
-           sodipodi:cy="2522.0312"
-           sodipodi:cx="-3523.625"
-           id="path5011-9-2-2-7-8"
-           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none;stroke-dashoffset:0"
-           sodipodi:type="arc" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           sodipodi:nodetypes="cccc"
-           inkscape:connector-curvature="0"
-           id="path4441-5-7-9-8-3-0-0-5-5-2-7-8-2-45-5-0-9-11-5"
-           d="m -2656.1374,3038.7453 c -30.0055,2.7604 -35.8919,20.0357 -41.3979,31.5296 m 0.774,0.5448 c -10.7735,-23.9718 -33.8544,-31.5136 -43.2398,-33.0744"
-           style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:3.03664303;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-        <path
-           inkscape:export-ydpi="67.648125"
-           inkscape:export-xdpi="67.648125"
-           inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
-           sodipodi:nodetypes="csccccc"
-           inkscape:connector-curvature="0"
-           id="path6055-8-52-7"
-           d="m -2656.3816,3036.72 c -5.929,0.6001 -10.9725,1.4608 -15.452,3.3139 -18.8475,7.7966 -25.5,24.3093 -25.298,29.5611 -0.25,-6.75 -14.125,-29.125 -43.25,-33.25 m 0.125,3.375 c 33.375,7 43.125,30.375 43.125,30.375 0,0 8.875,-28.5 41.25,-29.125"
-           style="fill:none;stroke:#d65649;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      </g>
+       id="g12117-48"
+       transform="matrix(0.48270778,0,0,0.48270778,1516.3598,-979.16912)"
+       inkscape:export-filename="C:\dev\BloomWebsite\app\img\LogoOnDark210x76.png"
+       inkscape:export-xdpi="49.189999"
+       inkscape:export-ydpi="49.189999">
+      <path
+         style="fill:#e5e5e5;fill-opacity:1;stroke:none"
+         d="m -2712.6495,3028.3151 c 14.9012,-1.8246 25.5449,-1.5205 25.5449,-1.5205 32.5391,29.8023 31.776,23.8975 34.2089,36.0617 l -2.7034,4.487 c -10.9478,-0.6083 -30.2891,-25.6476 -30.2891,-25.6476 l 1.2164,51.0898 -24.6326,0 -0.6082,-50.1774 c -21.9768,19.4439 -28.9013,26.5594 -34.6679,25.8489 -1.1905,-1.9557 0.3412,-6.5174 1.2436,-8.9735 2.128,-5.7927 30.6874,-31.1684 30.6874,-31.1684 z"
+         id="path3103-2-6-5-2-4-1-3-2-0-3-3-4-9-8-8-4-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccsc"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         sodipodi:nodetypes="csssccc"
+         style="fill:#d65649;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m -2740.377,3041.946 0,42.3316 c 0,23.3746 18.957,42.3175 42.3316,42.3175 23.3746,0 42.3173,-18.9429 42.3173,-42.3175 l 0,-42.3316 c -23.3745,0 -53.1594,23.127 -34.6445,51.0052 -3.5028,-23.3746 -26.6298,-51.0052 -50.0044,-51.0052 z"
+         id="path10-8-1-3-4-7-0-0-5-4-2-2-7-5-5-3-5-8-2-4-2"
+         inkscape:connector-curvature="0"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#e5e5e5;fill-opacity:1;stroke:none"
+         id="path3101-5-6-7-9-0-4-9-4-7-0-8-3-0-2-4-3-4"
+         sodipodi:cx="-557.7818"
+         sodipodi:cy="476.20172"
+         sodipodi:rx="54.447071"
+         sodipodi:ry="54.447071"
+         d="m -503.33473,476.20172 c 0,30.07029 -24.37678,54.44707 -54.44707,54.44707 -30.07029,0 -54.44707,-24.37678 -54.44707,-54.44707 0,-30.07029 24.37678,-54.44707 54.44707,-54.44707 30.07029,0 54.44707,24.37678 54.44707,54.44707 z"
+         transform="matrix(0.28824494,0,0,0.28824494,-2538.3392,2872.0462)"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         style="fill:none;stroke:#e5e5e5;stroke-width:3.03664303;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m -2655.7902,3041.7672 c -30.0055,2.7604 -38.6419,19.9107 -41.3979,31.5296 m 5.2743,34.9198 c 3.209,-39.5982 -17.6691,-62.0499 -48.1148,-66.4494"
+         id="path4441-5-7-9-8-3-0-0-5-5-2-7-8-2-45-5-3-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:#e5e5e5;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5011-0-8-51"
+         sodipodi:cx="-3523.625"
+         sodipodi:cy="2522.0312"
+         sodipodi:rx="4.625"
+         sodipodi:ry="5.625"
+         d="m -3519,2522.0313 c 0,3.1066 -2.0707,5.625 -4.625,5.625 -2.5543,0 -4.625,-2.5184 -4.625,-5.625 0,-3.1067 2.0707,-5.625 4.625,-5.625 2.5543,0 4.625,2.5183 4.625,5.625 z"
+         transform="matrix(0.72426329,0,0,1,-189.65951,543.52926)"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5011-9-2-2-7"
+         sodipodi:cx="-3523.625"
+         sodipodi:cy="2522.0312"
+         sodipodi:rx="4.625"
+         sodipodi:ry="5.625"
+         d="m -3519,2522.0313 c 0,3.1066 -2.0707,5.625 -4.625,5.625 -2.5543,0 -4.625,-2.5184 -4.625,-5.625 0,-3.1067 2.0707,-5.625 4.625,-5.625 2.5543,0 4.625,2.5183 4.625,5.625 z"
+         transform="matrix(0.64864865,0,0,1,-370.57191,540.77926)"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:3.03664303;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m -2656.1374,3038.7453 c -30.0055,2.7604 -35.8919,20.0357 -41.3979,31.5296 m 0.774,0.5448 c -10.7735,-23.9718 -33.8544,-31.5136 -43.2398,-33.0744"
+         id="path4441-5-7-9-8-3-0-0-5-5-2-7-8-2-45-5-0-9-11"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
+      <path
+         style="fill:none;stroke:#d65649;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -2656.3816,3036.72 c -5.929,0.6001 -10.9725,1.4608 -15.452,3.3139 -18.8475,7.7966 -25.5,24.3093 -25.298,29.5611 -0.25,-6.75 -14.125,-29.125 -43.25,-33.25 m 0.125,3.375 c 33.375,7 43.125,30.375 43.125,30.375 0,0 8.875,-28.5 41.25,-29.125"
+         id="path6055-8-52"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccc"
+         inkscape:export-filename="C:\dev\Bloom\artwork\LogoAgainstDark276x100.png"
+         inkscape:export-xdpi="67.648125"
+         inkscape:export-ydpi="67.648125" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
The previous logo had the problem that while Serif is available on
Linux it renders differently from Windows, resulting in "let's grow a
library" slogan overlapping "Bloom". This change makes use of the CSS
style for specifying the font (see
http://www.w3.org/TR/SVG/styling.html#StyleAttribute) and specifies
multiple fonts which are tried in the given order. Unfortunately
Inkscape in it's current version isn't terribly good in supporting
fallback fonts, but at least it seems to accept them.

This change is based on the original SVG file from commit 9493069.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary/187)
<!-- Reviewable:end -->
