### PR TITLE
Added tooltip to show English translation of language names

### DIFF
--- a/parseComCode/ReadMeParseComCloudCode.txt
+++ b/parseComCode/ReadMeParseComCloudCode.txt
@@ -3,8 +3,11 @@ As of first submission (11/24/14), the same code is in both the sandbox (deploy 
 
 To deploy a new version:
 See https://parse.com/docs/cloud_code_guide for more.
-You can download the Parse command line tool for Windows at https://parse.com/downloads/windows/console/parse.zip.
+You can download the Parse command line tool for Windows at https://parse.com/downloads/cloud_code/cli/parse-windows/latest
+N.B. The current version of the Parse CLI (2.0.9) is unstable. If the Parse CLI is not updated, see 06/03/15 notes below.
+
 Get the file and unzip it. I moved the output to I:\ParseComTools.
+(It is possible the download link will only contain an executable file. In that event, change the filename to parse.exe.)
 Initialize it for working on a particular Parse.com, using the command
 ParseComTools\parse new
 
@@ -16,10 +19,29 @@ The important file (apart from some keys you should protect) is parse/cloud/main
 Replace that file with the version checked in here.
 Edit it however you need to.
 
-The CLI produces a file parse/config/global.json. This file appears to be incompatible with the deploy function.
-You will need to edit the JSON file such that the "results" object only has one layer of properties
-which correspond to the parse.com project in question: appName, applicationId, masterKey.
-Part of global.json the CLI generates looks something like:
+Change the current directory to the newly created parse folder.
+Run 'parse deploy' (make sure that parse is in your path or you are running the ParseConsole provided in the zip)
+to make the current version live on parse.com.
+
+Running parse new only needs to be done once for each parse.com app on each developer computer.
+Subsequent calls may be made to parse deploy without re-authentication.
+
+Remember to copy any changes back to here and check them in.
+Remember to deploy your changes to the live site after you get them working in the sandbox.
+
+06/03/15 Usage Notes
+There appears to be a major issue with Parse CLI 2.0.9, which is currently the "latest" version on parse.com.
+The discussion at the following page confirms the issue is not local:
+https://groups.google.com/forum/#!searchin/parse-developers/parse%2420windows%2420cli%24202.0.9/parse-developers/WoRnDft4qmE/kkJeCkYhdAAJ
+Hopefully these issues are resolved, but in the event they are not follow the steps I took below.
+
+1) Download an older, but stable, version of Parse CLI: https://parse.com/downloads/windows/console/parse.zip.
+2) Unzip, and run ParseConsole.exe (making the parse command available in any directory).
+3) Call 'parse new', enter email and password, and enter '1'.
+    (N.B. only the first listed project in Parse is available for download, but any set of keys may be used for upload.)
+4) As a result of 'parse new', a folder called 'parse' will be created.
+5) Replace parse\cloud\main.js with current version of main.js
+6) Manually change the "results" part of parse\config\global.json from
     "results": {
       "applicationId": {
           "appName": <appName>,
@@ -32,17 +54,12 @@ Part of global.json the CLI generates looks something like:
           "masterKey": <masterKey>
       }
     }
-but should be changed to
+to
     "results": {
       "appName": <appName>,
       "applicationId": <appID>,
       "masterKey": <masterKey>
     }
-
-Run 'parse deploy' to make the current version live on parse.com.
-N.B. The 'deploy' part of this code requires that the current directory be the new 'parse' folder created.
-
-Running parse new only needs to be done once for each parse.com app on each developer computer.
-
-Remember to copy any changes back to here and check them in.
-Remember to deploy your changes to the live site after you get them working in the sandbox.
+This change is necessary due to an internal change to parse.com with outdated interface.
+7) Change current directory to parse.
+8) Call 'parse deploy'. Server code should now be updated.

--- a/parseComCode/ReadMeParseComCloudCode.txt
+++ b/parseComCode/ReadMeParseComCloudCode.txt
@@ -3,7 +3,7 @@ As of first submission (11/24/14), the same code is in both the sandbox (deploy 
 
 To deploy a new version:
 See https://parse.com/docs/cloud_code_guide for more.
-From a link there you can download the Parse command line tool for Windows.
+You can download the Parse command line tool for Windows at https://parse.com/downloads/windows/console/parse.zip.
 Get the file and unzip it. I moved the output to I:\ParseComTools.
 Initialize it for working on a particular Parse.com, using the command
 ParseComTools\parse new
@@ -11,10 +11,36 @@ ParseComTools\parse new
 This asks for an email, which is parse@bloomlibrary.org, and a password, which you will need to know!
 After you enter the right password, it asks which app you want to make cloud code for. Pick an appropriate number from the list.
 This creates a folder under whatever was the current directory when you did it...for example mine is at the root of I:.
+
 The important file (apart from some keys you should protect) is parse/cloud/main.js.
 Replace that file with the version checked in here.
 Edit it however you need to.
+
+The CLI produces a file parse/config/global.json. This file appears to be incompatible with the deploy function.
+You will need to edit the JSON file such that the "results" object only has one layer of properties
+which correspond to the parse.com project in question: appName, applicationId, masterKey.
+Part of global.json the CLI generates looks something like:
+    "results": {
+      "applicationId": {
+          "appName": <appName>,
+          "applicationId": <appID>,
+          "masterKey": <masterKey>
+      },
+      "masterKey": {
+          "appName": <appName>,
+          "applicationId": <appID>,
+          "masterKey": <masterKey>
+      }
+    }
+but should be changed to
+    "results": {
+      "appName": <appName>,
+      "applicationId": <appID>,
+      "masterKey": <masterKey>
+    }
+
 Run 'parse deploy' to make the current version live on parse.com.
+N.B. The 'deploy' part of this code requires that the current directory be the new 'parse' folder created.
 
 Running parse new only needs to be done once for each parse.com app on each developer computer.
 

--- a/parseComCode/main.js
+++ b/parseComCode/main.js
@@ -131,7 +131,7 @@ Parse.Cloud.define("defaultBooks", function(request, response) {
 
 // This function is used to set up the fields used in the bloom library.
 // Adding something here should be the ONLY way fields and classes are added to parse.com.
-// After adding one, it is recommended that you first deploy the modified cloud code
+// After adding one, it is recommended that you first deploy the modified cloud code (see ReadMeParseComCloudCode.txt)
 // to our 'test' project, run it, and verify that the result are as expected.
 // Then try on the bloomlibrarysandbox (where you should also develop and test the
 // functionality that uses the new fields).
@@ -201,7 +201,8 @@ Parse.Cloud.define("setupTables", function(request, response) {
             fields: [
                 {name: "ethnologueCode", type:"String"},
                 {name: "isoCode", type:"String"},
-                {name: "name", type:"String"}
+                {name: "name", type:"String"},
+                {name: "englishName", type:"String"}
             ]
         }
     ];

--- a/src/app/modules/browse/browse-controller.js
+++ b/src/app/modules/browse/browse-controller.js
@@ -133,7 +133,7 @@
             if (!$scope.initialized) {
                 return; // can't do useful query.
             }
-			bookService.getFilteredBookRange(first, count, $scope.searchText, $scope.shelf, $scope.lang, $scope.tag).then(function (result) {
+			bookService.getFilteredBookRange(first, count, $scope.searchText, $scope.shelf, $scope.lang, $scope.tag, "title", true).then(function (result) {
 				$scope.visibleBooks = result;
 			});
 		};

--- a/src/app/modules/browse/browse.tpl.html
+++ b/src/app/modules/browse/browse.tpl.html
@@ -15,7 +15,7 @@
             <div class="narrowSearch">
                 <h4>Narrow Search</h4>
                 <h5>Languages</h5>
-                <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a href="" ng-click="filterLanguage(lang.isoCode)">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('')">Clear</a></div></div>
+                <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a href="" ng-click="filterLanguage(lang.isoCode)" tooltip="{{lang.englishName}}" tooltip-trigger="{{'mouseenter'}}">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('')">Clear</a></div></div>
                 <h5>Tags</h5>
                 <div ng-repeat="tag in topTags"><div ng-class="{activeFilter: currentTag == tag}"><a class="tagItem" href="" ng-click="filterTag(tag)">{{tag}}</a><a class="clear right" href="" ng-click="filterTag('')">Clear</a></div></div>
             </div>


### PR DESCRIPTION
Added "englishName" field to language class in parseComCode\main.js

Updated parseComCode\ReadMeParseComCloudCode.txt. I included a more specific link for the CLI tool, added a note on where to run the parse deploy command, and made some notes on necessary manual changes to the global.json file.