### PR TITLE
BL-2288 Preview language message should not be in tooltip

### DIFF
--- a/src/app/modules/app/app.js
+++ b/src/app/modules/app/app.js
@@ -251,15 +251,20 @@
 				$(element).fancybox({
 					'overlayShow': true,
                     'helpers':{title: { type:'inside', position:'top'}},
-                    // The title comes from a title attribute in the element with the pdfoverlay directive, e.g.,
+                    // The title comes from an overlayTitle attribute in the element with the pdfoverlay directive, e.g.,
                     // in detail.tpl.html for the Preview button. So it can't contain HTML. We insert markup here
                     // to put an Info icon in front, interpret [] as requesting bold, and interpret | as line
                     // breaks.
                     afterLoad: function() {
-                        if(!this.title) {
+                        var title = '';
+                        try {
+                            title = this.element.context.attributes['overlayTitle'].value;
+                        }
+                        catch(_) {}
+                        if(!title) {
                             return;  // if it's empty don't insert the icon etc.
                         }
-                        var temp=this.title.replace('[', '<b>').replace(']', '</b>').split('|');
+                        var temp=title.replace('[', '<b>').replace(']', '</b>').split('|');
                         var result = '<table><tbody><tr><td><i class="icon-info-sign" style="font-size:5em;margin-right:12px;position:relative;top:-4px"></i></td><td>';
                         for(var i = 0; i < temp.length; i++){
                             var after = '';

--- a/src/app/modules/detail/detail.tpl.html
+++ b/src/app/modules/detail/detail.tpl.html
@@ -39,7 +39,7 @@
             <a href="" ng-click="chooseBookshelves()"><i tooltip="Add/Remove book from bookshelf" tooltip-placement="right" ng-class="{'icon-folder-open': true, 'icon-hidden':!canSetBookshelf, inBookshelf: isBookFeatured}"></i></a>
             <div class="pull-right">
             <!-- I have no idea why, but without ng-click (even though it is empty), the setting of preview=true in the url in the pdfoverlay directive (in app.js) doesn't work -->
-            <a ng-href="{{book.baseUrl | makePreviewUrl}}" title="{{book | previewLangInfo}}" ng-click="" pdfoverlay analytics-on analytics-event="Preview" analytics-book="{{book.objectId}}">
+            <a ng-href="{{book.baseUrl | makePreviewUrl}}" overlayTitle="{{book | previewLangInfo}}" ng-click="" pdfoverlay analytics-on analytics-event="Preview" analytics-book="{{book.objectId}}">
                 <button type="button" class="btn btn-default"><i class="notranslate" class="icon-eye-open"></i> Preview</button></a>
             <!--<a ng-href="downloadBook{{book.bookOrder}}" tooltip="No-Preflight Download to the Bloom software on your computer, so that you can use it as a shell book." ng-hide="!skipDownloadPreflight">-->
                 <!--<button type="button" class="btn btn-default" ng-click="close()"><i class="icon-download"></i> Open in Bloom</button></a>-->


### PR DESCRIPTION
The title attribute aimed at the pdfoverlay directive was also
interpreted by something else. Using a different attribute name
unfortunately made it a little harder to get to.