### PR TITLE
Fixed footer height

### DIFF
--- a/src/app/app.less
+++ b/src/app/app.less
@@ -174,7 +174,7 @@ div.container.not-centered {
 /*
  * Sticky footer
  */
-@footerHeight: 42px;
+@footerHeight: 46px;
 html {
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
Due to something with the mixpanel mobile analytics image in the footer, the footer was causing pages that should have fit in a single screen to have a scrollbar for a few pixels.