### PR TITLE
Added download history with column in datagrid

### DIFF
--- a/parseComCode/main.js
+++ b/parseComCode/main.js
@@ -239,6 +239,24 @@ Parse.Cloud.beforeSave("books", function(request, response) {
 	response.success();
 });
 
+Parse.Cloud.afterSave("downloadHistory", function(request) {
+    Parse.Cloud.useMasterKey();
+
+    var entry = request.object;
+    var bookId = entry.get('bookId');
+
+    var booksClass = Parse.Object.extend('books');
+    var query = new Parse.Query(booksClass);
+
+    query.get(bookId, {success: function(book) {
+        var currentDownloadCount = book.get('downloadCount') || 0;
+        book.set('downloadCount', currentDownloadCount + 1);
+        book.save();
+    }, error: function(object, error) {
+        console.log("get error: " + error);
+    }});
+});
+
 // Return the books that should be shown in the default browse view.
 // Currently this is those in the Featured bookshelf, followed by all the others.
 // Each group is sorted alphabetically by title.
@@ -355,6 +373,7 @@ Parse.Cloud.define("setupTables", function(request, response) {
                 {name: "copyright", type:"String"},
                 {name: "credits", type:"String"},
                 {name: "currentTool", type:"String"},
+                {name: "downloadCount", type:"Number"},
                 {name: "downloadSource", type:"String"},
                 {name: "experimental", type:"Boolean"},
                 {name: "folio", type:"Boolean"},
@@ -385,6 +404,14 @@ Parse.Cloud.define("setupTables", function(request, response) {
                 {name: "name", type:"String"},
                 {name: "books", type:"Relation<books>"},
                 {name: "owner", type:"Pointer<_User>"}
+            ]
+        },
+        {
+            name: "downloadHistory",
+            fields: [
+                {name: "bookId", type: "String"},
+                {name: "userIp", type: "String"},
+                {name: "userName", type: "String"}
             ]
         },
         {

--- a/src/app/modules/common/services.js
+++ b/src/app/modules/common/services.js
@@ -528,6 +528,21 @@ angular.module('BloomLibraryApp.services', ['restangular'])
             $cookies["currentpage"] = 1;
         };
 	} ])
+    .service('downloadHistoryService', ['Restangular', '$http', 'authService', function(restangular, $http, authService) {
+        this.logDownload = function(bookId) {
+            $http.get('http://icanhazip.com').success(function(ip) {
+                console.log(ip);
+
+                var username = authService.userName();
+
+                var newEntry = {bookId: bookId, userIp: ip, userName: username};
+
+                var downloadHistory = restangular.withConfig(authService.config()).all('classes/downloadHistory');
+
+                downloadHistory.post(newEntry);
+            });
+        };
+    }])
     .service('languageService', ['$rootScope', '$q', '$filter', 'errorHandlerService', function($rootScope, $q, $filter, errorHandlerService) {
         var languageList; // Used to cache the list
     

--- a/src/app/modules/datagrid/datagrid-controller.js
+++ b/src/app/modules/datagrid/datagrid-controller.js
@@ -87,6 +87,7 @@
 								return new Date(dateWithTime.getFullYear(), dateWithTime.getMonth(), dateWithTime.getDate());
 							}()),
 							copyright: item.copyright.match("^Copyright ") ? item.copyright.substring(10) : item.copyright,
+							downloadCount: item.downloadCount || 0,
 							license: item.license,
 							updatedAt: (function () {
 								var dateWithTime = new Date(item.updatedAt);
@@ -218,6 +219,19 @@
 						visible: false
 					},
 					{ field: 'pageCount', displayName: 'Pages', width: '*', minWidth: 15, maxWidth: 60, enableCellEdit: false,
+						filters: [
+							{
+								condition: uiGridConstants.filter.GREATER_THAN_OR_EQUAL,
+								placeholder: ' >='
+							},
+							{
+								condition: uiGridConstants.filter.LESS_THAN_OR_EQUAL,
+								placeholder: ' <='
+							}
+						],
+						visible: false
+					},
+					{ field: 'downloadCount', displayName: 'Downloads', width: '*', minWidth: 15, maxWidth: 60, enableCellEdit: false,
 						filters: [
 							{
 								condition: uiGridConstants.filter.GREATER_THAN_OR_EQUAL,

--- a/src/app/modules/download/download-controller.js
+++ b/src/app/modules/download/download-controller.js
@@ -68,12 +68,14 @@
                     }
                 });
         } ])
-        .controller('DownloadCtrl', ['$stateParams', 'bookService', '$timeout', '$analytics', function($stateParams, bookService, $timeout, $analytics) {
+        .controller('DownloadCtrl', ['$stateParams', 'bookService', '$timeout', '$analytics', 'downloadHistoryService', function($stateParams, bookService, $timeout, $analytics, downloadHistoryService) {
             //get the book for which we're going to show the details asynchronously, then start the download
             bookService.getBookById($stateParams.bookId).then(function (book) {
                 // Without $timeout, setting the href will cancel the analytics request
                 $timeout(function() {
                     $analytics.eventTrack('Download Book', {book: book.objectId, href: book.bookOrder, bookTitle:book.title});
+
+                    downloadHistoryService.logDownload(book.objectId);
                 });
                 window.location.href = book.bookOrder + '&title=' + encodeURIComponent(book.title);
             });


### PR DESCRIPTION
When a user downloads a book, a request is sent to icanhazip.com to get the user's ip address. The ip, bookId, and username (and date by default) are then saved in an entry on the downloadHistory table on parse.com. After the entry is saved, the book's downloadCount is incremented via cloud-code aftersave on downloadHistory.