### PR TITLE
Fix display of wrong "paired" language (BL-2397)

### DIFF
--- a/src/app/modules/app/app.js
+++ b/src/app/modules/app/app.js
@@ -87,12 +87,14 @@
 		.controller('LeftSidebar', ['$scope', '$state', '$location', '$rootScope', 'bookService', 'languageService', 'tagService', 'authService', '$modal',
             function ($scope, $state, $location, $rootScope, bookService, languageService, tagService, authService, $modal) {
             $scope.currentLang = $location.$$search.lang;
+            $scope.currentLangName = $location.$$search.langname;
             $scope.currentTag = $location.$$search.tag;
             $scope.currentShelf = $location.$$search.shelf;
             $scope.wantLeftBar = $location.$$path.substring(1, 7) == 'browse';
             $scope.isLoggedIn = authService.isLoggedIn();
             $rootScope.$on('$locationChangeSuccess', function() {
                 $scope.currentLang = $location.$$search.lang;
+                $scope.currentLangName = $location.$$search.langname;
                 $scope.currentTag = $location.$$search.tag;
                 $scope.currentShelf = $location.$$search.shelf;
                 $scope.wantLeftBar = $location.$$path.substring(1, 7) == 'browse';
@@ -104,9 +106,9 @@
                     windowClass: 'ccmodal'
                 });
             };
-            $scope.filterLanguage = function(language) {
+            $scope.filterLanguage = function(language,languageName) {
                 bookService.resetCurrentPage();
-                $state.go('browse', {lang:language}); // keep other params unchanged.
+                $state.go('browse', {lang:language, langname:languageName}); // keep other params unchanged.
             };
             $scope.filterTag = function(tagName) {
                 bookService.resetCurrentPage();
@@ -116,7 +118,7 @@
                 bookService.resetCurrentPage();
                 if (shelfName === '') {
                     // User selected "All Books"
-                    $state.go('browse', {search:'', shelf:shelfName, lang:'', tag:''});
+                    $state.go('browse', {search:'', shelf:shelfName, lang:'', langname:'', tag:''});
                 } else {
                     $state.go('browse', {search:'', shelf:shelfName}); // keep other params unchanged.
                 }
@@ -167,7 +169,8 @@
                 //Search through otherLanguages
                 for(var i = 0; i < $scope.otherLanguages.length; i++) {
                     //If the currentLang is in the other list, add it to the top (visible) list
-                    if($scope.otherLanguages[i].isoCode == $scope.currentLang) {
+                    if ($scope.otherLanguages[i].isoCode == $scope.currentLang &&
+                        (!$scope.currentLangName || ($scope.otherLanguages[i].name == $scope.currentLangName))) {
                         $scope.topLanguages.unshift($scope.otherLanguages.splice(i, 1)[0]);
                         $scope.topLanguages.sort(compareLang);
                         break;

--- a/src/app/modules/browse/browse-controller.js
+++ b/src/app/modules/browse/browse-controller.js
@@ -7,7 +7,7 @@
 			parent: 'requireLoginResolution',
 			//review: I had wanted to have the main view be named, and have the name be 'main', but then nothing would show
 			//it's as if the top level view cannot be named. (note that you can specify it by saying views: {'@':
-			url: "/browse?search&shelf&lang&tag&allLicenses",
+			url: "/browse?search&shelf&lang&langname&tag&allLicenses",
 			templateUrl: 'modules/browse/browse.tpl.html',
 			controller: 'BrowseCtrl',
 			title: 'Book Library'
@@ -50,6 +50,7 @@
 		$scope.searchText = $stateParams["search"];
         $scope.shelfName = $stateParams["shelf"];
         $scope.lang = $stateParams["lang"];
+        $scope.langName = $stateParams["langname"];
         $scope.tag = $stateParams["tag"];
         $scope.allLicenses = $stateParams["allLicenses"] === "true";
         $scope.numHiddenBooks = 0;
@@ -107,7 +108,7 @@
             var params = {
                 count: count,
                 shelf: shelfLabel,
-                language: languageService.getDisplayName($scope.lang),
+                language: $scope.langName ? $scope.langName : languageService.getDisplayName($scope.lang),
                 bookOrBooks: booksTranslation,
                 tag: tagService.getDisplayName($scope.tag),
                 searchText: $scope.searchText

--- a/src/app/modules/browse/browse.tpl.html
+++ b/src/app/modules/browse/browse.tpl.html
@@ -15,11 +15,11 @@
             <div class="narrowSearch">
                 <h4>Narrow Search</h4>
                 <h5>Languages</h5>
-                <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a class="languageItem" href="" ng-click="filterLanguage(lang.isoCode)" tooltip="{{lang.englishName != lang.name ? lang.englishName : ''}}" tooltip-placement="right" tooltip-trigger="{{'mouseenter'}}">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('')">Clear</a></div></div>
+                <div ng-repeat="lang in topLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a class="languageItem" href="" ng-click="filterLanguage(lang.isoCode,lang.name)" tooltip="{{lang.englishName != lang.name ? lang.englishName : ''}}" tooltip-placement="right" tooltip-trigger="{{'mouseenter'}}">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('','')">Clear</a></div></div>
                 <div ng-show="otherLanguages.length">
                     <a href="" ng-click="toggleVisibilityOfOtherLanguages($event)">{{localizeMore(otherLanguages.length,otherLanguagesHidden)}}</a>
                     <div style="display:none">
-                        <div ng-repeat="lang in otherLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a class="languageItem" href="" ng-click="filterLanguage(lang.isoCode)" tooltip="{{lang.englishName != lang.name ? lang.englishName : ''}}" tooltip-placement="right" tooltip-trigger="{{'mouseenter'}}">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('')">Clear</a></div></div>
+                        <div ng-repeat="lang in otherLanguages"><div ng-class="{activeFilter: currentLang == lang.isoCode}"><a class="languageItem" href="" ng-click="filterLanguage(lang.isoCode,lang.name)" tooltip="{{lang.englishName != lang.name ? lang.englishName : ''}}" tooltip-placement="right" tooltip-trigger="{{'mouseenter'}}">{{lang.name}}</a><a class="clear right" href="" ng-click="filterLanguage('','')">Clear</a></div></div>
                     </div>
                 </div>
                 <div ng-repeat="category in tagCategories">


### PR DESCRIPTION
This works by matching both ISO code and language name.

This may be closer to what John Hatton wanted in the issue than my earlier proposed fix.