### PR TITLE
Adjust location of "Beta" in banner (BL-2395)

### DIFF
--- a/src/app/app.less
+++ b/src/app/app.less
@@ -19,10 +19,10 @@ a {
   position: absolute;
   top: 10px;
   @media(max-width:@navbar-small-breakpoint-max) {
-    left: 115px;
+    left: 215px;
   }
   @media(min-width:@navbar-small-breakpoint) {
-    left: 185px;
+    left: 285px;
   }
   color: @lightGray;
   font-size: 16px;


### PR DESCRIPTION
The fix merely relocates the "Beta" an inch or so to the right.  Looking at the css, I don't know how to make to the location adjust to the length of the banner string being displayed.