### PR TITLE
Fix error when modifying books through the datagrid

### DIFF
--- a/src/app/modules/common/services.js
+++ b/src/app/modules/common/services.js
@@ -523,12 +523,16 @@ angular.module('BloomLibraryApp.services', ['restangular'])
 
             this.modifyBookField = function(book, field, value, updateSource) {
                 var rBook = restangular.withConfig(authService.config()).one('classes/books', book.objectId);
-                rBook[field] = value;
                 if (authService.isUserAdministrator()) {
                     updateSource += ' (admin)';
                 }
-                rBook['updateSource'] = updateSource;
-                rBook.put();
+
+                var putParams = {};
+                putParams[field] = value;
+                putParams['updateSource'] = updateSource;
+
+                // Have to do customPUT so it doesn't try to send "id" as a field
+                rBook.customPUT(putParams);
             };
 
         this.resetCurrentPage = function () {


### PR DESCRIPTION
We were sending "id" as a field which was trying to create
the "id" column on the database table.