### PR TITLE
BL-2737 Detail view should show createdAt not updatedAt

### DIFF
--- a/src/app/modules/detail/detail.tpl.html
+++ b/src/app/modules/detail/detail.tpl.html
@@ -20,6 +20,7 @@
             </div>
             <!--div class="credits">{{book.credits  }}</div-->
             <div class="status">
+                <!-- Don't use updatedAt here because it is changed by things other than uploading, for example, when the librarian adds a tag (BL-2737). -->
                 <span class="fori18n">Uploaded:</span> <span class="notranslate">{{book.createdAt | cleanDate}}</span> <span class="fori18n">by</span>
                 <span class="notranslate">
                     <a ng-show="canReportViolation" href="mailto:{{book.uploader.email}}?subject=A%20request%20about%20a%20book%20you%20contributed%20to%20bloomlibrary.org:%20{{book.title}}%20({{book.objectId}})&body=This%20book%20may%20be%20found%20at%20{{location}}.">{{book.uploader.email | obfuscate}}</a>

--- a/src/app/modules/detail/detail.tpl.html
+++ b/src/app/modules/detail/detail.tpl.html
@@ -20,7 +20,7 @@
             </div>
             <!--div class="credits">{{book.credits  }}</div-->
             <div class="status">
-                <span class="fori18n">Uploaded:</span> <span class="notranslate">{{book.updatedAt | cleanDate}}</span> <span class="fori18n">by</span>
+                <span class="fori18n">Uploaded:</span> <span class="notranslate">{{book.createdAt | cleanDate}}</span> <span class="fori18n">by</span>
                 <span class="notranslate">
                     <a ng-show="canReportViolation" href="mailto:{{book.uploader.email}}?subject=A%20request%20about%20a%20book%20you%20contributed%20to%20bloomlibrary.org:%20{{book.title}}%20({{book.objectId}})&body=This%20book%20may%20be%20found%20at%20{{location}}.">{{book.uploader.email | obfuscate}}</a>
                     <a ng-hide="canReportViolation" href="" ng-click="showPleaseLogIn()">{{book.uploader.email | obfuscate}}</a>


### PR DESCRIPTION
This is especially important when the librarian changes tags
but there has not actually been a new upload of the book.
But it is at least plausible to show when it was first uploaded.