### PR TITLE
Remove wkhtmltopdf from about page credits (BL-4337)

### DIFF
--- a/src/app/modules/static/about.tpl.pug
+++ b/src/app/modules/static/about.tpl.pug
@@ -54,9 +54,6 @@ mixin link(display, url)
 			a(href='http://call.canil.ca') SynPhony
 			| : Norbert Rennert (SIL International)
 		li
-			a(href='http://code.google.com/p/wkhtmltopdf') wkhtmltoimage
-			| : Jan Habermann, Christian Sciberras and Jakob Truelsen
-		li
 			a(href="http://webfx.eae.net/") WebFX
 		li
 			a(href="https://github.com/KevinSheedy/jquery.alphanum") jquery.alphanum


### PR DESCRIPTION
We don't use this in any shipping version of Bloom, and the text
didn't match the link properly anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary/269)
<!-- Reviewable:end -->
